### PR TITLE
Profile (Save Button Enables on Form Complete)

### DIFF
--- a/lib/screens/profile.dart
+++ b/lib/screens/profile.dart
@@ -31,6 +31,13 @@ class _ProfileState extends State<Profile> {
     initializeDateFormatting();
   }
 
+  bool _saveButtonEnabled() {
+    if (_genderInput != null && _dobInput.text.isNotEmpty && _heightInput.text.isNotEmpty) {
+      return true;
+    } 
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -111,6 +118,7 @@ class _ProfileState extends State<Profile> {
                         ),
                         child: TextField(
                             controller: _dobInput,
+                            onChanged: (value) {setState((){});},
                             readOnly: true,
                             onTap: () async {
                               DateTime? pickedDate = await showDatePicker(
@@ -152,7 +160,10 @@ class _ProfileState extends State<Profile> {
                         height: 20,
                         width: 60,
                       ),
-                      child: TextField(controller: _heightInput)
+                      child: TextField(
+                        controller: _heightInput, 
+                        onChanged: (value) {setState((){});}
+                      )
                   ),
                   const Padding(
                     padding: EdgeInsets.fromLTRB(5, 0, 0, 0),
@@ -163,7 +174,7 @@ class _ProfileState extends State<Profile> {
               Padding(
                 padding: const EdgeInsets.fromLTRB(10, 15, 10, 40),
                 child: ElevatedButton(
-                    onPressed: null,
+                    onPressed: _saveButtonEnabled() ? () {} : null,
                     style: ElevatedButton.styleFrom(
                         minimumSize: const Size.fromHeight(50)
                     ),


### PR DESCRIPTION
Actual functionality is in the last commit.

**Story:**
https://trello.com/c/5EUSYRBk

**Testing:**
1) When form is empty, Save button is disabled.
2) When form is complete, Save button is enabled.
3) When form is made incomplete again, Save button is disabled.
4) Save button status updates on text change rather than on blur.

**Screenshots:**
Before completing form:
<img src="https://user-images.githubusercontent.com/29754340/202276544-f8545ef5-6a22-47c7-aabe-4ee3e6a81195.png" width="250" height="200" />
After completing form:
<img src="https://user-images.githubusercontent.com/29754340/202276546-bb9f0961-f781-4127-8163-729f6b2fd9df.png" width="250" height="200" />
After un-completing form:
<img src="https://user-images.githubusercontent.com/29754340/202276538-f00fcbb3-0072-468a-9d9f-7673f3965f4c.png" width="250" height="200" />